### PR TITLE
fix: error-prone tests when caching unit instances

### DIFF
--- a/junisert-core/src/integrationTest/java/io/github/mattiaspersson09/junisert/core/test/HasGettersIntegrationTest.java
+++ b/junisert-core/src/integrationTest/java/io/github/mattiaspersson09/junisert/core/test/HasGettersIntegrationTest.java
@@ -30,6 +30,8 @@ import io.github.mattiaspersson09.junisert.testunits.getter.TwoLettersOrLessBean
 import io.github.mattiaspersson09.junisert.value.common.ObjectValueGenerator;
 import io.github.mattiaspersson09.junisert.value.common.PrimitiveValueGenerator;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +44,7 @@ public class HasGettersIntegrationTest {
 
     @BeforeAll
     static void beforeAll() {
-        valueService = new TestValueService(new PrimitiveValueGenerator(), new ObjectValueGenerator());
+        valueService = new TestValueService(Arrays.asList(new PrimitiveValueGenerator(), new ObjectValueGenerator()));
     }
 
     @BeforeEach

--- a/junisert-core/src/integrationTest/java/io/github/mattiaspersson09/junisert/core/test/ImplementsEqualsIntegrationTest.java
+++ b/junisert-core/src/integrationTest/java/io/github/mattiaspersson09/junisert/core/test/ImplementsEqualsIntegrationTest.java
@@ -57,7 +57,9 @@ public class ImplementsEqualsIntegrationTest {
     @Test
     void givenUnit_whenNotDeclaringImplementationOfEqualsMethod_thenFailsTest() {
         assertThatThrownBy(() -> implementsEquals.test(Unit.of(MissingEquals.class)))
-                .isInstanceOf(UnitAssertionError.class);
+                .isInstanceOf(UnitAssertionError.class)
+                .hasMessageContaining("was expected to implement")
+                .hasMessageContaining("equals");
     }
 
     @Test

--- a/junisert-core/src/integrationTest/java/io/github/mattiaspersson09/junisert/core/test/TestValueService.java
+++ b/junisert-core/src/integrationTest/java/io/github/mattiaspersson09/junisert/core/test/TestValueService.java
@@ -20,7 +20,6 @@ import io.github.mattiaspersson09.junisert.api.value.UnsupportedTypeError;
 import io.github.mattiaspersson09.junisert.api.value.Value;
 import io.github.mattiaspersson09.junisert.api.value.ValueGenerator;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,10 +28,6 @@ final class TestValueService implements ValueService {
 
     TestValueService(ValueGenerator<?> generator) {
         this(Collections.singletonList(generator));
-    }
-
-    TestValueService(ValueGenerator<?>... generators) {
-        this(Arrays.asList(generators));
     }
 
     TestValueService(List<ValueGenerator<?>> generators) {

--- a/junisert-core/src/main/java/io/github/mattiaspersson09/junisert/core/test/HasGetters.java
+++ b/junisert-core/src/main/java/io/github/mattiaspersson09/junisert/core/test/HasGetters.java
@@ -79,7 +79,7 @@ public class HasGetters implements UnitTest {
                 }
             };
 
-            Injection injection = new Injection(method, valueService);
+            Injection injection = new Injection(method, new InstanceCreator());
             injection.setup(instance -> field.setValue(instance, value));
             injection.shouldResultIn(instance -> Objects.equals(value, getterGetValue.apply(instance)));
             injection.onInjectionFail(() -> new UnitAssertionError("Failed to invoke getter"));

--- a/junisert-core/src/main/java/io/github/mattiaspersson09/junisert/core/test/HasSetters.java
+++ b/junisert-core/src/main/java/io/github/mattiaspersson09/junisert/core/test/HasSetters.java
@@ -66,7 +66,7 @@ public class HasSetters implements UnitTest {
             }
 
             Value<?> argument = valueService.getValue(field.getType());
-            Injection injection = new Injection(method, valueService);
+            Injection injection = new Injection(method, new InstanceCreator());
 
             Object value = argument.get();
             Object empty = argument.asEmpty();

--- a/junisert-core/src/main/java/io/github/mattiaspersson09/junisert/core/test/ImplementsEquals.java
+++ b/junisert-core/src/main/java/io/github/mattiaspersson09/junisert/core/test/ImplementsEquals.java
@@ -40,8 +40,9 @@ public class ImplementsEquals implements UnitTest {
             throw new UnitAssertionError(unit.getName() + " was expected to implement the equals method");
         }
 
-        Object instance = valueService.getValue(unit.getType()).get();
-        Object instance2 = valueService.getValue(unit.getType()).get();
+        InstanceCreator instanceCreator = new InstanceCreator();
+        Object instance = instanceCreator.createInstance(unit);
+        Object instance2 = instanceCreator.createInstance(unit);
 
         if (!isPassingNullCheck(instance)) {
             LOGGER.fail(details(unit, "fails null check"), "to not equal null objects", "it did");

--- a/junisert-core/src/main/java/io/github/mattiaspersson09/junisert/core/test/Injection.java
+++ b/junisert-core/src/main/java/io/github/mattiaspersson09/junisert/core/test/Injection.java
@@ -37,10 +37,10 @@ import java.util.function.Supplier;
  * @see Invokable
  * @see ValueService
  */
-public class Injection {
+class Injection {
     private static final Logger LOGGER = Logger.getLogger("Injection");
 
-    private final ValueService valueService;
+    private final InstanceCreator instanceCreator;
     private final Invokable injectionTarget;
     private Predicate<Object> setup;
     private Predicate<Object> result;
@@ -50,11 +50,11 @@ public class Injection {
      * Creates a new test injection.
      *
      * @param injectionTarget to inject values into from a unit instance
-     * @param valueService    that can create unit instances
+     * @param instanceCreator that can create unit instances
      */
-    public Injection(Invokable injectionTarget, ValueService valueService) {
+    Injection(Invokable injectionTarget, InstanceCreator instanceCreator) {
         this.injectionTarget = injectionTarget;
-        this.valueService = valueService;
+        this.instanceCreator = instanceCreator;
         this.setup = setup -> true;
         this.result = result -> true;
     }
@@ -105,7 +105,7 @@ public class Injection {
      * @see #onInjectionFail(Supplier)
      */
     public boolean inject(Object... arguments) {
-        Object unitInstance = valueService.getValue(injectionTarget.getParent()).get();
+        Object unitInstance = instanceCreator.createInstance(injectionTarget.getParent());
 
         if (!setup.test(unitInstance)) {
             LOGGER.warn("Injection precondition setup was unsuccessful");

--- a/junisert-core/src/test/java/io/github/mattiaspersson09/junisert/core/test/HasGettersTest.java
+++ b/junisert-core/src/test/java/io/github/mattiaspersson09/junisert/core/test/HasGettersTest.java
@@ -54,10 +54,6 @@ public class HasGettersTest {
     @Test
     void acceptsBeanStyleGetters() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(Object.class);
-        doReturn((Value<?>) BeanStyle::new).when(valueService).getValue(BeanStyle.class);
-        doReturn((Value<?>) BooleanBeanStyle::new).when(valueService).getValue(BooleanBeanStyle.class);
-        doReturn((Value<?>) TwoLettersOrLessBeanStyle::new).when(valueService)
-                .getValue(TwoLettersOrLessBeanStyle.class);
         doReturn(new BooleanValue()).when(valueService).getValue(boolean.class);
 
         hasGetters.test(Unit.of(BeanStyle.class));
@@ -69,8 +65,6 @@ public class HasGettersTest {
     void acceptsBuilderStyleGetters() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(Object.class);
         doReturn(new BooleanValue()).when(valueService).getValue(boolean.class);
-        doReturn((Value<?>) BuilderStyle::new).when(valueService).getValue(BuilderStyle.class);
-        doReturn((Value<?>) BooleanBuilderStyle::new).when(valueService).getValue(BooleanBuilderStyle.class);
 
         hasGetters.test(Unit.of(BuilderStyle.class));
         hasGetters.test(Unit.of(BooleanBuilderStyle.class));
@@ -79,7 +73,6 @@ public class HasGettersTest {
     @Test
     void whenMoreThanOneGetter_thenIsSatisfiedWithAnyWorking() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(any());
-        doReturn((Value<?>) BeanAndBuilderStyle::new).when(valueService).getValue(BeanAndBuilderStyle.class);
 
         hasGetters.test(Unit.of(BeanAndBuilderStyle.class));
     }
@@ -87,7 +80,6 @@ public class HasGettersTest {
     @Test
     void whenMoreThanOneGetter_andOnlyOneIsWorking_thenIsSatisfiedWithOneWorking() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(any());
-        doReturn((Value<?>) TwoButOnlyOneWorking::new).when(valueService).getValue(TwoButOnlyOneWorking.class);
 
         hasGetters.test(Unit.of(TwoButOnlyOneWorking.class));
     }

--- a/junisert-core/src/test/java/io/github/mattiaspersson09/junisert/core/test/HasSettersTest.java
+++ b/junisert-core/src/test/java/io/github/mattiaspersson09/junisert/core/test/HasSettersTest.java
@@ -51,7 +51,6 @@ public class HasSettersTest {
     @Test
     void acceptsBeanStyleSetters() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(any());
-        doReturn((Value<?>) BeanStyle::new).when(valueService).getValue(BeanStyle.class);
 
         hasSetters.test(Unit.of(BeanStyle.class));
     }
@@ -59,7 +58,6 @@ public class HasSettersTest {
     @Test
     void acceptsBuilderStyleSetters() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(any());
-        doReturn((Value<?>) BuilderStyle::new).when(valueService).getValue(BuilderStyle.class);
 
         hasSetters.test(Unit.of(BuilderStyle.class));
     }
@@ -67,7 +65,6 @@ public class HasSettersTest {
     @Test
     void acceptsHybridStyleSetters() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(any());
-        doReturn((Value<?>) HybridStyle::new).when(valueService).getValue(HybridStyle.class);
 
         hasSetters.test(Unit.of(HybridStyle.class));
     }
@@ -75,7 +72,6 @@ public class HasSettersTest {
     @Test
     void whenMoreThanOneSetter_thenIsSatisfiedWithAnyWorking() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(any());
-        doReturn((Value<?>) BeanAndBuilderStyle::new).when(valueService).getValue(BeanAndBuilderStyle.class);
 
         hasSetters.test(Unit.of(BeanAndBuilderStyle.class));
     }
@@ -83,7 +79,6 @@ public class HasSettersTest {
     @Test
     void whenMoreThanOneSetter_andOnlyOneIsWorking_thenIsSatisfiedWithOneWorking() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(any());
-        doReturn((Value<?>) TwoButOnlyOneWorking::new).when(valueService).getValue(TwoButOnlyOneWorking.class);
 
         hasSetters.test(Unit.of(TwoButOnlyOneWorking.class));
     }

--- a/junisert-core/src/test/java/io/github/mattiaspersson09/junisert/core/test/ImplementsEqualsTest.java
+++ b/junisert-core/src/test/java/io/github/mattiaspersson09/junisert/core/test/ImplementsEqualsTest.java
@@ -53,9 +53,6 @@ public class ImplementsEqualsTest {
     @Test
     void whenHasWellImplementedEquals_thenImplementsEquals() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(Object.class);
-        doReturn((Value<?>) WellImplementedEquals::new)
-                .when(valueService)
-                .getValue(WellImplementedEquals.class);
 
         implementsEquals.test(Unit.of(WellImplementedEquals.class));
     }
@@ -63,9 +60,6 @@ public class ImplementsEqualsTest {
     @Test
     void whenHasWellImplementedEquals_andExtendingOtherClass_thenImplementsEquals() {
         doReturn((Value<?>) Object::new).when(valueService).getValue(Object.class);
-        doReturn((Value<?>) WellImplementedEqualsExtendingBase::new)
-                .when(valueService)
-                .getValue(WellImplementedEqualsExtendingBase.class);
 
         implementsEquals.test(Unit.of(WellImplementedEqualsExtendingBase.class));
     }


### PR DESCRIPTION
When creating instances, needs to create instances without using caches, ValueService's WILL be using caches. If a unit instance is cached it will make tests error-prone due to references, updating a field in one instance would then alter another instance.

resolves #34